### PR TITLE
Concurrency issue fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+SeekingAlpha/tutorial/__pycache__/*
+*.html
+SeekingAlpha/tutorial/spiders/__pycache__/*
+.vscode/settings.json

--- a/SeekingAlpha/tutorial/runner.py
+++ b/SeekingAlpha/tutorial/runner.py
@@ -1,0 +1,17 @@
+import os
+from scrapy.cmdline import execute
+
+os.chdir(os.path.dirname(os.path.realpath(__file__)))
+
+try:
+    execute(
+        [
+            'scrapy',
+            'crawl',
+            'quotes',
+            '-o',
+            'out.json',
+        ]
+    )
+except SystemExit:
+    pass

--- a/SeekingAlpha/tutorial/spiders/SeekingAlpha.py
+++ b/SeekingAlpha/tutorial/spiders/SeekingAlpha.py
@@ -19,22 +19,20 @@ class QuotesSpider(scrapy.Spider):
 
     name = "quotes"
     custom_settings = {
-            # 'LOG_LEVEL': 'CRITICAL', # 'DEBUG'
-            # 'LOG_ENABLED': False,
-            'DOWNLOAD_DELAY': 5 # 0.25 == 250 ms of delay, 1 == 1000ms of delay, etc.
+            #'LOG_LEVEL': 'CRITICAL', # 'DEBUG'
+            #'LOG_ENABLED': True,
+            #'COOKIES_ENABLED' : False,
+            'CONCURRENT_REQUESTS_PER_DOMAIN':1,
+            'CONCURRENT_REQUESTS': 2,
+            'DOWNLOAD_DELAY': 2 # 0.25 == 250 ms of delay, 1 == 1000ms of delay, etc.
     }
 
     def start_requests(self):
         # GET LAST INDEX PAGE NUMBER
         urls = [ 'https://seekingalpha.com/earnings/earnings-call-transcripts/9999' ]
-        for url in urls:
-            yield scrapy.Request(url=url, callback=self.parse)
-
-    def parse(self, response):
-        data = response.css("#paging > ul.list-inline > li:last-child a::text")
-        last_page = data.extract()
-        last_page = int(last_page[0])
+        last_page=32
         for x in range(0, last_page+1):
+            print("Number: %d",x)
             # DEBUGGING: CHECK ONLY FIRST ELEMENT
             if debug_mode == True and x > 0:
                 break


### PR DESCRIPTION
Ich habe noch nie mit Python gearbeitet, aber mir stellt sich das Problem folgendermaßen dar:

start_requests liefert einen Iterator über alle URLs zurück die von scrapy bearbeitet werden.
Du hast aber nur einen Eintrag zurück geliefert, der dann intern im callback weitere Request startet. 
Für diese weiteren (internen) Requests wird anscheinend kein Limit von scrapy berücksichtigt, das heißt du hast tausende Requests gleichzeitig gestartet und das wird vom Webserver abgewiesen.

Mit den Limits in Custom settings musst du mal ein wenig rumspielen, was der server erlaubt.
Manchmal wird totzdem noch ein 403 zurückgeliefert, da musst du dann schauen, wie du damit umgehst (nochmal probieren, ignorieren...)
